### PR TITLE
Use flakehub push action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,13 +44,11 @@ jobs:
             nix build ".#nixosConfigurations.${host}.${NIX_TARGET}" --out-link "result-${host}"
           done
       - name: Push to FlakeHub
-        env:
-          FLAKEHUB_API_TOKEN: ${{ secrets.FLAKEHUB_API_TOKEN }}
-        run: |
-          set -euo pipefail
-          fh push \
-            --visibility public \
-            --name kcalvelli/nixos_config \
-            --rolling \
-            --include-output-paths result-edge \
-            --include-output-paths result-pangolin
+        uses: DeterminateSystems/flakehub-push@main
+        with:
+          name: kcalvelli/nixos_config
+          visibility: public
+          rolling: true
+          include-output-paths: |
+            result-edge
+            result-pangolin


### PR DESCRIPTION
## Summary
- replace the manual `fh push` invocation with the DeterminateSystems FlakeHub push action
- remove the unused `FLAKEHUB_API_TOKEN` environment configuration from the action step

## Testing
- Not run (workflow change)


------
https://chatgpt.com/codex/tasks/task_e_68dfce1229bc8333b60601211d671d6e