### PR TITLE
Fix FlakeHub push inputs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,16 +41,13 @@ jobs:
         run: |
           set -euo pipefail
           for host in edge pangolin; do
+            rm -f "result-${host}"
             nix build ".#nixosConfigurations.${host}.${NIX_TARGET}" --out-link "result-${host}"
           done
       - name: Push to FlakeHub
-        env:
-          FLAKEHUB_API_TOKEN: ${{ secrets.FLAKEHUB_API_TOKEN }}
-        run: |
-          set -euo pipefail
-          fh push \
-            --visibility public \
-            --name kcalvelli/nixos_config \
-            --rolling \
-            --include-output-paths result-edge \
-            --include-output-paths result-pangolin
+        uses: DeterminateSystems/flakehub-push@main
+        with:
+          name: kcalvelli/nixos_config
+          visibility: public
+          rolling: true
+          include-output-paths: true


### PR DESCRIPTION
## Summary
- ensure each host build refreshes its result link before invoking nix build
- rely on flakehub-push's automatic result detection instead of unsupported inputs

## Testing
- Not run (workflow change)


------
https://chatgpt.com/codex/tasks/task_e_68dfce1229bc8333b60601211d671d6e